### PR TITLE
Allow generation of longer passwords.

### DIFF
--- a/Units/LSHashs.pas
+++ b/Units/LSHashs.pas
@@ -22,7 +22,7 @@ uses
   LSUtils, MD5, SHA1, SysUtils;
 
 type
-  TLSPwsGenAmount = 2..10;
+  TLSPwsGenAmount = 2..255;
 
 { Generate MD5 string from a string. (see: http://en.wikipedia.org/wiki/MD5) }
 function LSMD5(const AString: string): string;


### PR DESCRIPTION
Function `LSPasswordGenerator`  was allowing the user to generate passwords only smaller than 10 characters. While it might be adequate for some situations, a password of 10 characters consisting of random uppercase and lowercase letters, numbers and symbols (generated [here](https://lastpass.com/generatepassword.php), for example), will recieve a mediocre rating [here](https://howsecureismypassword.net/). A password of 15 characters is considered more secure, let alone a 20-characters long one.

Therefore, I propose a rise to the upper bound of `TLSPwsGenAmount` to 255 characters. Surely, that number is an overkill, but it surely is safer and more future-proof than 32 or 64. It would also allow the function to be used to generate longer API keys or just random strings.
